### PR TITLE
Increase size of PipeName

### DIFF
--- a/fsw/src/skeleton_app.h
+++ b/fsw/src/skeleton_app.h
@@ -88,7 +88,7 @@ typedef struct
     /*
     ** Initialization data (not reported in housekeeping)...
     */
-    char     PipeName[16];
+    char     PipeName[18];
     uint16   PipeDepth;
 } SKELETON_AppData_t;
 


### PR DESCRIPTION
Resolves issue of `SKELETON_AppData.PipeName` overflowing into `SKELETON_AppData.PipeDepth` as described in #2.