### PR TITLE
Fixing direct import of skeleton_app into latest cfs

### DIFF
--- a/fsw/platform_inc/skeleton_app_msgids.h
+++ b/fsw/platform_inc/skeleton_app_msgids.h
@@ -30,9 +30,9 @@
 #ifndef _skeleton_app_msgids_h_
 #define _skeleton_app_msgids_h_
 
-#define SKELETON_APP_CMD_MID            0x1882
-#define SKELETON_APP_SEND_HK_MID        0x1883
-#define SKELETON_APP_HK_TLM_MID		0x0883
+#define SKELETON_APP_CMD_MID            0x1872
+#define SKELETON_APP_SEND_HK_MID        0x1873
+#define SKELETON_APP_HK_TLM_MID		    0x0873
 
 #endif /* _skeleton_app_msgids_h_ */
 

--- a/fsw/src/skeleton_app.h
+++ b/fsw/src/skeleton_app.h
@@ -49,16 +49,6 @@
 *************************************************************************/
 
 /*
- * Buffer to hold telemetry data prior to sending
- * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
- */
-typedef union
-{
-    CFE_SB_Msg_t        MsgHdr;
-    SKELETON_HkTlm_t      HkTlm;
-} SKELETON_HkBuffer_t;
-
-/*
 ** Global Data
 */
 typedef struct
@@ -72,7 +62,7 @@ typedef struct
     /*
     ** Housekeeping telemetry packet...
     */
-    SKELETON_HkBuffer_t     HkBuf;
+    SKELETON_HkTlm_t     HkBuf;
 
     /*
     ** Run Status variable used in the main processing loop
@@ -83,12 +73,13 @@ typedef struct
     ** Operational data (not reported in housekeeping)...
     */
     CFE_SB_PipeId_t    CommandPipe;
-    CFE_SB_MsgPtr_t    MsgPtr;
+    //CFE_SB_MsgPtr_t    MsgPtr;
+    CFE_SB_Buffer_t     *SBBufPtr;
 
     /*
     ** Initialization data (not reported in housekeeping)...
     */
-    char     PipeName[16];
+    char     PipeName[CFE_MISSION_MAX_API_LEN];
     uint16   PipeDepth;
 } SKELETON_AppData_t;
 
@@ -101,13 +92,13 @@ typedef struct
 */
 void  SKELETON_AppMain(void);
 int32 SKELETON_AppInit(void);
-void  SKELETON_ProcessCommandPacket(CFE_SB_MsgPtr_t Msg);
-void  SKELETON_ProcessGroundCommand(CFE_SB_MsgPtr_t Msg);
-int32 SKELETON_ReportHousekeeping(const CCSDS_CommandPacket_t *Msg);
+void  SKELETON_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
+void  SKELETON_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr);
+int32 SKELETON_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg);
 int32 SKELETON_ResetCounters(const SKELETON_ResetCounters_t *Msg);
 int32 SKELETON_Process(const SKELETON_Process_t *Msg);
 int32 SKELETON_Noop(const SKELETON_Noop_t *Msg);
 void  SKELETON_GetCrc(const char *TableName);
-bool  SKELETON_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength);
+bool  SKELETON_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t ExpectedLength);
 
 #endif /* _skeleton_app_h_ */

--- a/fsw/src/skeleton_app_msg.h
+++ b/fsw/src/skeleton_app_msg.h
@@ -44,7 +44,7 @@
 */
 typedef struct
 {
-   uint8    CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
 } SKELETON_NoArgsCmd_t;
 
@@ -73,10 +73,10 @@ typedef struct
 
 typedef struct
 {
-    uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
+    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
     SKELETON_HkTlm_Payload_t  Payload;
 
-} OS_PACK SKELETON_HkTlm_t;
+} SKELETON_HkTlm_t;
 
 #endif /* _skeleton_app_msg_h_ */
 


### PR DESCRIPTION
* Issue as highlighted in https://github.com/nasa/skeleton_app/issues/5
* I was able to replicate the issue in Linux and Raspbian

* Fixed the files to align to the latest functions and structures of the CFE
* This version of skeleton_app can be directly copied into the apps folder of CFS. It will not give any errors when the make command is run.
* Also the MID of messages have been updated in "skeleton_app_msgids.h" to avoid conflict with the Message Ids of sample_app which comes with the CFS. There is a high chance that the developer trying to learn might have both sample_app and skeleton_app included. Hence its important to have non-conflicting ids.
