### PR TITLE
compile with latest cFS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(CFE_SKELETON_APP C)
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 
-aux_source_directory(fsw/src APP_SRC_FILES)
-
 # Create the app module
-add_cfe_app(skeleton_app ${APP_SRC_FILES})
+add_cfe_app(skeleton_app fsw/src/skeleton_app.c)
+

--- a/fsw/src/skeleton_app.h
+++ b/fsw/src/skeleton_app.h
@@ -49,16 +49,6 @@
 *************************************************************************/
 
 /*
- * Buffer to hold telemetry data prior to sending
- * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
- */
-typedef union
-{
-    CFE_SB_Msg_t        MsgHdr;
-    SKELETON_HkTlm_t      HkTlm;
-} SKELETON_HkBuffer_t;
-
-/*
 ** Global Data
 */
 typedef struct
@@ -72,7 +62,7 @@ typedef struct
     /*
     ** Housekeeping telemetry packet...
     */
-    SKELETON_HkBuffer_t     HkBuf;
+    SKELETON_HkTlm_t     HkTlm;
 
     /*
     ** Run Status variable used in the main processing loop
@@ -83,13 +73,13 @@ typedef struct
     ** Operational data (not reported in housekeeping)...
     */
     CFE_SB_PipeId_t    CommandPipe;
-    CFE_SB_MsgPtr_t    MsgPtr;
 
     /*
     ** Initialization data (not reported in housekeeping)...
     */
     char     PipeName[16];
     uint16   PipeDepth;
+
 } SKELETON_AppData_t;
 
 /****************************************************************************/
@@ -101,13 +91,13 @@ typedef struct
 */
 void  SKELETON_AppMain(void);
 int32 SKELETON_AppInit(void);
-void  SKELETON_ProcessCommandPacket(CFE_SB_MsgPtr_t Msg);
-void  SKELETON_ProcessGroundCommand(CFE_SB_MsgPtr_t Msg);
-int32 SKELETON_ReportHousekeeping(const CCSDS_CommandPacket_t *Msg);
+void  SKELETON_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
+void  SKELETON_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr);
+int32 SKELETON_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg);
 int32 SKELETON_ResetCounters(const SKELETON_ResetCounters_t *Msg);
 int32 SKELETON_Process(const SKELETON_Process_t *Msg);
 int32 SKELETON_Noop(const SKELETON_Noop_t *Msg);
 void  SKELETON_GetCrc(const char *TableName);
-bool  SKELETON_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength);
+bool  SKELETON_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 
-#endif /* _skeleton_app_h_ */
+#endif 

--- a/fsw/src/skeleton_app_msg.h
+++ b/fsw/src/skeleton_app_msg.h
@@ -44,7 +44,7 @@
 */
 typedef struct
 {
-   uint8    CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_MSG_CommandHeader_t CmdHeader;
 
 } SKELETON_NoArgsCmd_t;
 
@@ -69,16 +69,17 @@ typedef struct
     uint8              CommandErrorCounter;
     uint8              CommandCounter;
     uint8              spare[2];
+
 } SKELETON_HkTlm_Payload_t;
 
 typedef struct
 {
-    uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
-    SKELETON_HkTlm_Payload_t  Payload;
+    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
+    SKELETON_HkTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 
-} OS_PACK SKELETON_HkTlm_t;
+} SKELETON_HkTlm_t;
 
-#endif /* _skeleton_app_msg_h_ */
+#endif 
 
 /************************/
 /*  End of File Comment */


### PR DESCRIPTION
I can't drop the current skeleton_app in cFS/apps, add to targets.cmake, and compile. I get lots of compiler errors. I fixed the errors by switching out the old function calls with the ones found in cFS/apps/sample_app. 