### PR TITLE
Modern cmake for skeleton app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(CFE_SKELETON_APP C)
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 
-aux_source_directory(fsw/src APP_SRC_FILES)
-
 # Create the app module
-add_cfe_app(skeleton_app ${APP_SRC_FILES})
+add_cfe_app(skeleton_app fsw/src/skeleton_app.c)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.6.4)
 project(CFE_SKELETON_APP C)
 
-include_directories(fsw/mission_inc)
-include_directories(fsw/platform_inc)
-
 # Create the app module
 add_cfe_app(skeleton_app fsw/src/skeleton_app.c)
 
+target_include_directories(skeleton_app PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fsw/platform_inc>
+  $<INSTALL_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/fsw/platform_inc> )

--- a/fsw/src/skeleton_app.c
+++ b/fsw/src/skeleton_app.c
@@ -63,6 +63,7 @@ void SKELETON_AppMain( void )
     /*
     ** SKELETON Runloop
     */
+    
     while (CFE_ES_RunLoop(&SKELETON_AppData.RunStatus) == true)
     {
         status = CFE_SB_ReceiveBuffer(&SBBufPtr,
@@ -110,8 +111,9 @@ int32 SKELETON_AppInit( void )
     ** Initialize app configuration data
     */
     SKELETON_AppData.PipeDepth = SKELETON_PIPE_DEPTH;
-
-    strcpy(SKELETON_AppData.PipeName, "SKELETON_CMD_PIPE");
+    
+    strncpy(SKELETON_AppData.PipeName, "SKELETON_CMD_PIPE", sizeof(SKELETON_AppData.PipeName));
+    SKELETON_AppData.PipeName[sizeof(SKELETON_AppData.PipeName) - 1] = 0;
 
     /*
     ** Register the events
@@ -127,7 +129,7 @@ int32 SKELETON_AppInit( void )
     ** Initialize housekeeping packet (clear user data area).
     */
     CFE_MSG_Init(&SKELETON_AppData.HkTlm.TlmHeader.Msg,
-                   SKELETON_APP_HK_TLM_MID,
+                   CFE_SB_ValueToMsgId(SKELETON_APP_HK_TLM_MID),
                    sizeof(SKELETON_AppData.HkTlm));
 
     /*
@@ -146,7 +148,7 @@ int32 SKELETON_AppInit( void )
     /*
     ** Subscribe to Housekeeping request commands
     */
-    status = CFE_SB_Subscribe(SKELETON_APP_SEND_HK_MID,
+    status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SKELETON_APP_SEND_HK_MID),
                               SKELETON_AppData.CommandPipe);
     if (status != CFE_SUCCESS)
     {
@@ -158,7 +160,7 @@ int32 SKELETON_AppInit( void )
     /*
     ** Subscribe to ground command packets
     */
-    status = CFE_SB_Subscribe(SKELETON_APP_CMD_MID,
+    status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(SKELETON_APP_CMD_MID),
                               SKELETON_AppData.CommandPipe);
     if (status != CFE_SUCCESS )
     {
@@ -194,7 +196,7 @@ void SKELETON_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr )
 
     CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MsgId);
 
-    switch (MsgId)
+    switch (CFE_SB_MsgIdToValue(MsgId))
     {
         case SKELETON_APP_CMD_MID:
             SKELETON_ProcessGroundCommand(SBBufPtr);
@@ -208,7 +210,7 @@ void SKELETON_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr )
             CFE_EVS_SendEvent(SKELETON_INVALID_MSGID_ERR_EID,
                               CFE_EVS_EventType_ERROR,
          	              "SKELETON: invalid command packet,MID = 0x%x",
-                              MsgId);
+                              CFE_SB_MsgIdToValue(MsgId));
             break;
     }
 

--- a/fsw/src/skeleton_app.h
+++ b/fsw/src/skeleton_app.h
@@ -49,16 +49,6 @@
 *************************************************************************/
 
 /*
- * Buffer to hold telemetry data prior to sending
- * Defined as a union to ensure proper alignment for a CFE_SB_Msg_t type
- */
-typedef union
-{
-    CFE_SB_Msg_t        MsgHdr;
-    SKELETON_HkTlm_t      HkTlm;
-} SKELETON_HkBuffer_t;
-
-/*
 ** Global Data
 */
 typedef struct
@@ -72,7 +62,7 @@ typedef struct
     /*
     ** Housekeeping telemetry packet...
     */
-    SKELETON_HkBuffer_t     HkBuf;
+    SKELETON_HkTlm_t     HkTlm;
 
     /*
     ** Run Status variable used in the main processing loop
@@ -83,13 +73,13 @@ typedef struct
     ** Operational data (not reported in housekeeping)...
     */
     CFE_SB_PipeId_t    CommandPipe;
-    CFE_SB_MsgPtr_t    MsgPtr;
 
     /*
     ** Initialization data (not reported in housekeeping)...
     */
     char     PipeName[16];
     uint16   PipeDepth;
+
 } SKELETON_AppData_t;
 
 /****************************************************************************/
@@ -101,13 +91,13 @@ typedef struct
 */
 void  SKELETON_AppMain(void);
 int32 SKELETON_AppInit(void);
-void  SKELETON_ProcessCommandPacket(CFE_SB_MsgPtr_t Msg);
-void  SKELETON_ProcessGroundCommand(CFE_SB_MsgPtr_t Msg);
-int32 SKELETON_ReportHousekeeping(const CCSDS_CommandPacket_t *Msg);
+void  SKELETON_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
+void  SKELETON_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr);
+int32 SKELETON_ReportHousekeeping(const CFE_MSG_CommandHeader_t *Msg);
 int32 SKELETON_ResetCounters(const SKELETON_ResetCounters_t *Msg);
 int32 SKELETON_Process(const SKELETON_Process_t *Msg);
 int32 SKELETON_Noop(const SKELETON_Noop_t *Msg);
 void  SKELETON_GetCrc(const char *TableName);
-bool  SKELETON_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength);
+bool  SKELETON_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 
-#endif /* _skeleton_app_h_ */
+#endif 

--- a/fsw/src/skeleton_app_msg.h
+++ b/fsw/src/skeleton_app_msg.h
@@ -44,7 +44,7 @@
 */
 typedef struct
 {
-   uint8    CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_MSG_CommandHeader_t CmdHeader;
 
 } SKELETON_NoArgsCmd_t;
 
@@ -69,16 +69,17 @@ typedef struct
     uint8              CommandErrorCounter;
     uint8              CommandCounter;
     uint8              spare[2];
+
 } SKELETON_HkTlm_Payload_t;
 
 typedef struct
 {
-    uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
-    SKELETON_HkTlm_Payload_t  Payload;
+    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
+    SKELETON_HkTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 
-} OS_PACK SKELETON_HkTlm_t;
+} SKELETON_HkTlm_t;
 
-#endif /* _skeleton_app_msg_h_ */
+#endif 
 
 /************************/
 /*  End of File Comment */


### PR DESCRIPTION
This refactor the CMakeLists by removing the old `include_directories` feature by the more modern `target_include_directories` approach.
It is a follow-up of this : https://github.com/nasa/skeleton_app/pull/8